### PR TITLE
add EasyHubspot::HubspotApiError wrapper

### DIFF
--- a/lib/easy_hubspot.rb
+++ b/lib/easy_hubspot.rb
@@ -5,6 +5,7 @@ require 'easy_hubspot/client'
 require 'easy_hubspot/contact'
 require 'easy_hubspot/version'
 require 'easy_hubspot/generators/install_generator'
+require 'easy_hubspot/exceptions'
 
 require 'httparty'
 require 'json'

--- a/lib/easy_hubspot/client.rb
+++ b/lib/easy_hubspot/client.rb
@@ -33,7 +33,10 @@ module EasyHubspot
       def parse_response(res)
         return if res.body.nil?
 
-        JSON.parse res, symbolize_names: true
+        parsed_res = JSON.parse res, symbolize_names: true
+        raise EasyHubspot::HubspotApiError, parsed_res[:message] if parsed_res[:status] == 'error'
+
+        parsed_res
       end
     end
   end

--- a/lib/easy_hubspot/exceptions.rb
+++ b/lib/easy_hubspot/exceptions.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+module EasyHubspot
+  class Error < StandardError; end
+  class HubspotApiError < Error; end
+end

--- a/spec/fixtures/contact_not_found.json
+++ b/spec/fixtures/contact_not_found.json
@@ -1,0 +1,5 @@
+{
+    "status": "error",
+    "message": "resource not found",
+    "correlationId": "3e72c6a8-4bcb-43e9-9c1f-cd7d20ab6699"
+}

--- a/spec/fixtures/duplicate_contact.json
+++ b/spec/fixtures/duplicate_contact.json
@@ -1,0 +1,1 @@
+{"status": "error", "message": "Contact already exists. Existing ID: 801","correlationId": "0703a695-8b86-4d98-b58a-8fb03ccef58a","category": "CONFLICT"}


### PR DESCRIPTION
- Adds a `EasyHubspot::HubspotApiError` wrapper around api requests. This will make it easier to handle errors.