### PR TITLE
Directly send rspec test coverage to codeclimate

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,12 +26,6 @@ jobs:
           gem install bundler
           bundle install --jobs 4 --retry 3
           COVERAGE=true bundle exec rspec
-      - name: Upload coverage results
-        uses: joshmfrankel/simplecov-check-action@main
-        with:
-          minimum_suite_coverage: 90
-          minimum_file_coverage: 90
-          github_token: ${{ secrets.GITHUB_TOKEN }}
       - name: Publish code coverage
         run: |
           export GIT_BRANCH="${GITHUB_REF/refs\/heads\//}"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,8 +21,6 @@ jobs:
           bundle install --jobs 4 --retry 3
           COVERAGE=true bundle exec rspec
       - name: Upload coverage results
-        uses: actions/upload-artifact@master
-        if: always()
+        uses: joshmfrankel/simplecov-check-action@main
         with:
-          name: coverage-report
-          path: coverage
+          github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,6 +16,11 @@ jobs:
         with:
           ruby-version: "3.1.x"
           bundle-chase: true
+      - name: Setup Code Climate test-reporter
+        run: |
+          curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
+          chmod +x ./cc-test-reporter
+          ./cc-test-reporter before-build
       - name: Build and test with Rake
         run: |
           gem install bundler
@@ -27,3 +32,7 @@ jobs:
           minimum_suite_coverage: 90
           minimum_file_coverage: 90
           github_token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Publish code coverage
+        run: |
+          export GIT_BRANCH="${GITHUB_REF/refs\/heads\//}"
+          ./cc-test-reporter after-build -r ${{secrets.CC_TEST_REPORTER_ID}}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,6 +8,7 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions: write-all
     steps:
       - uses: actions/checkout@v3
       - name: Set up Ruby 3.1
@@ -23,4 +24,6 @@ jobs:
       - name: Upload coverage results
         uses: joshmfrankel/simplecov-check-action@main
         with:
+          minimum_suite_coverage: 90
+          minimum_file_coverage: 90
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/Gemfile
+++ b/Gemfile
@@ -14,5 +14,5 @@ group :development, :test do
 end
 
 group :test do
-  gem 'simplecov', '~> 0.21.2'
+  gem 'simplecov', '~> 0.17.0'
 end

--- a/easy_hubspot.gemspec
+++ b/easy_hubspot.gemspec
@@ -44,6 +44,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rubocop', '~> 1.2'
   spec.add_development_dependency 'rubocop-rake', '~> 0.6.0'
   spec.add_development_dependency 'rubocop-rspec', '~> 2.18.1'
-  spec.add_development_dependency 'simplecov', '~> 0.21.2'
+  spec.add_development_dependency 'simplecov', '~> 0.17.0'
   spec.add_development_dependency 'webmock', '~> 3.14'
 end


### PR DESCRIPTION
This PR fixs the uploading issues created in https://github.com/oroth8/easy_hubspot/pull/8

Now we send to code climate directly in the action.

Also reverting to use gem `'simplecov', '~> 0.17.0'` instead due to incompatibility issues