### PR TITLE
Take gem out of beta version, Release major version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,9 @@
 ## [Official Release]
-- [0.1.7] - 2023-02-10
-- [0.1.8] - 2023-02-10
-- [0.1.9] - 2023-02-14 https://github.com/oroth8/easy_hubspot/pull/6
-- [0.1.10] - 2023-02-14 https://github.com/oroth8/easy_hubspot/pull/7
+- [1.0.0] - 2023-02-22 
 
 ## [Unreleased]
 
-## [Initial releases]
+## [Initial releases (Beta)]
 - [0.1.0] - 2023-02-08
 - [0.1.1] - 2023-02-09
 - [0.1.2] - 2023-02-09
@@ -14,3 +11,7 @@
 - [0.1.4] - 2023-02-09
 - [0.1.5] - 2023-02-09
 - [0.1.6] - 2023-02-09
+- [0.1.7] - 2023-02-10
+- [0.1.8] - 2023-02-10
+- [0.1.9] - 2023-02-14 https://github.com/oroth8/easy_hubspot/pull/6
+- [0.1.10] - 2023-02-14 https://github.com/oroth8/easy_hubspot/pull/7

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # EasyHubspot
-Stable: ![stable version](https://img.shields.io/badge/version-0.1.10-green)
-Latest: ![latest version](https://img.shields.io/badge/version-0.1.10-yellow)
+Stable: ![stable version](https://img.shields.io/badge/version-1.0.0-green)
+Latest: ![latest version](https://img.shields.io/badge/version-1.0.0-yellow)
 [![CI](https://github.com/oroth8/easy_hubspot/actions/workflows/ci.yml/badge.svg)](https://github.com/oroth8/easy_hubspot/actions/workflows/ci.yml)
 [![Code Climate](https://codeclimate.com/github/oroth8/easy_hubspot/badges/gpa.svg)](https://codeclimate.com/github/oroth8/easy_hubspot)
 [![Test Coverage](https://api.codeclimate.com/v1/badges/c55dfda6142769b8209c/test_coverage)](https://codeclimate.com/github/oroth8/easy_hubspot/test_coverage)

--- a/lib/easy_hubspot/version.rb
+++ b/lib/easy_hubspot/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module EasyHubspot
-  VERSION = '0.1.10'
+  VERSION = '1.0.0'
 end


### PR DESCRIPTION
This gem is no longer in beta development and is ready for production. The release tag structure will now follow a more streamlined process. 