### PR TITLE
update github ci to use ruby 3.2.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,14 +11,14 @@ jobs:
       - uses: actions/checkout@v3
       - uses: ruby/setup-ruby@v1
         with:
-          ruby-version: "3.2.0"
+          ruby-version: "3.2.2"
           bundler-cache: true
       - run: bundle exec rubocop
   test:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby: ["2.6.10", "2.7.7", "3.0.5", "3.1.3", "3.2.0"]
+        ruby: ["2.6.10", "2.7.7", "3.0.5", "3.1.3", "3.2.0", "3.2.2"]
     steps:
       - uses: actions/checkout@v3
       - uses: ruby/setup-ruby@v1

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # EasyHubspot
-Stable: ![stable version](https://img.shields.io/badge/version-1.0.0-green)
-Latest: ![latest version](https://img.shields.io/badge/version-1.0.0-yellow)
+Stable: ![stable version](https://img.shields.io/badge/version-1.0.1-green)
+Latest: ![latest version](https://img.shields.io/badge/version-1.0.1-yellow)
 [![CI](https://github.com/oroth8/easy_hubspot/actions/workflows/ci.yml/badge.svg)](https://github.com/oroth8/easy_hubspot/actions/workflows/ci.yml)
 [![Code Climate](https://codeclimate.com/github/oroth8/easy_hubspot/badges/gpa.svg)](https://codeclimate.com/github/oroth8/easy_hubspot)
 [![Test Coverage](https://api.codeclimate.com/v1/badges/c55dfda6142769b8209c/test_coverage)](https://codeclimate.com/github/oroth8/easy_hubspot/test_coverage)


### PR DESCRIPTION
- Updates ruby version testing matrix to include latest stable ruby version `3.2.2`
- Updates `README.md` gem stable and latest badges to match current gem version `1.0.1`