### PR TITLE
Feature/adding multi tenant support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,8 @@
 name: RSpec with SimpleCov
 on:
-  pull_request: _target
+  pull_request_target:
+    types:
+      - opened
   push:
     branches:
       - main

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,6 @@
 name: RSpec with SimpleCov
 on:
-  pull_request:
+  pull_request: _target
   push:
     branches:
       - main

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,6 +3,7 @@ on:
   pull_request_target:
     types:
       - opened
+      - edited
   push:
     branches:
       - main

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 ## [Official Release]
+- [1.0.2] - 2024-09-05 https://github.com/oroth8/easy_hubspot/pull/19
+  - Adding `access_token` to class methods to allow for overriding the initializer 
 - [1.0.0] - 2023-02-22 https://github.com/oroth8/easy_hubspot/pull/10
 
 ## [Unreleased]

--- a/README.md
+++ b/README.md
@@ -203,18 +203,14 @@ Please refrence the [hubspot docs](https://developers.hubspot.com/docs/api/crm/l
   EasyHubspot::LineItem.delete_line_item(123)
 ```
 
-## Error Handling
+## Multiple Access Tokens
+
+If you need to choose your access token at call time, you can pass the access token as an argument to class methods as 
+follows:
 
 ```ruby
-def call
-  begin
-    EasyHubspot::Contact.create_contact(body)
-  rescue EasyHubspot::HubspotApiError => e
-    # handle error code
-    # e.message = 'Contact already exists. Existing ID: 801'
-    Rails.logger.info(e.message)
-  end
-end
+# Finds the contact using the access token provided at call time instead of the one set during initialization
+EasyHubspot::Contact.get_contact(123, different_access_token)
 ```
 
 ## Development

--- a/lib/easy_hubspot/base.rb
+++ b/lib/easy_hubspot/base.rb
@@ -4,9 +4,9 @@ module EasyHubspot
   # class EasyHubspot::Base
   class Base
     class << self
-      def headers
+      def headers(access_token = nil)
         { "Content-Type" => 'application/json',
-          "Authorization" => "Bearer #{EasyHubspot.configuration.access_token}" }
+          "Authorization" => "Bearer #{access_token || EasyHubspot.configuration.access_token}" }
       end
 
       def email?(string)

--- a/lib/easy_hubspot/client.rb
+++ b/lib/easy_hubspot/client.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require 'pry'
 
 module EasyHubspot

--- a/lib/easy_hubspot/client.rb
+++ b/lib/easy_hubspot/client.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+require 'pry'
 
 module EasyHubspot
   # EasyHubspot::Client

--- a/lib/easy_hubspot/contact.rb
+++ b/lib/easy_hubspot/contact.rb
@@ -6,32 +6,32 @@ module EasyHubspot
     class << self
       CONTACT_ENDPOINT = 'crm/v3/objects/contacts'
 
-      def get_contact(contact_id)
-        Client.do_get(determine_endpoint(contact_id), headers)
+      def get_contact(contact_id, access_token = nil)
+        Client.do_get(determine_endpoint(contact_id), headers(access_token))
       end
 
-      def get_contacts
-        Client.do_get(CONTACT_ENDPOINT, headers)
+      def get_contacts(access_token = nil)
+        Client.do_get(CONTACT_ENDPOINT, headers(access_token))
       end
 
-      def create_contact(body)
-        Client.do_post(CONTACT_ENDPOINT, body, headers)
+      def create_contact(body, access_token = nil)
+        Client.do_post(CONTACT_ENDPOINT, body, headers(access_token))
       end
 
-      def update_contact(contact_id, body)
-        Client.do_patch(determine_endpoint(contact_id), body, headers)
+      def update_contact(contact_id, body, access_token = nil)
+        Client.do_patch(determine_endpoint(contact_id), body, headers(access_token))
       end
 
-      def delete_contact(contact_id)
-        Client.do_delete(determine_endpoint(contact_id), headers)
+      def delete_contact(contact_id, access_token = nil)
+        Client.do_delete(determine_endpoint(contact_id), headers(access_token))
       end
 
-      def update_or_create_contact(email, body)
-        res = get_contact(email)
+      def update_or_create_contact(email, body, access_token = nil)
+        res = get_contact(email, access_token)
         if res && res[:id]
-          update_contact(email, body)
+          update_contact(email, body, access_token)
         else
-          create_contact(body)
+          create_contact(body, access_token)
         end
       end
 

--- a/lib/easy_hubspot/deal.rb
+++ b/lib/easy_hubspot/deal.rb
@@ -6,24 +6,24 @@ module EasyHubspot
     class << self
       DEAL_ENDPOINT = 'crm/v3/objects/deals'
 
-      def get_deal(deal_id)
-        Client.do_get(deal_id_endpoint(deal_id), headers)
+      def get_deal(deal_id, access_token = nil)
+        Client.do_get(deal_id_endpoint(deal_id), headers(access_token))
       end
 
-      def get_deals
-        Client.do_get(DEAL_ENDPOINT, headers)
+      def get_deals(access_token = nil)
+        Client.do_get(DEAL_ENDPOINT, headers(access_token))
       end
 
-      def create_deal(body)
-        Client.do_post(DEAL_ENDPOINT, body, headers)
+      def create_deal(body, access_token = nil)
+        Client.do_post(DEAL_ENDPOINT, body, headers(access_token))
       end
 
-      def update_deal(deal_id, body)
-        Client.do_patch(deal_id_endpoint(deal_id), body, headers)
+      def update_deal(deal_id, body, access_token = nil)
+        Client.do_patch(deal_id_endpoint(deal_id), body, headers(access_token))
       end
 
-      def delete_deal(deal_id)
-        Client.do_delete(deal_id_endpoint(deal_id), headers)
+      def delete_deal(deal_id, access_token = nil)
+        Client.do_delete(deal_id_endpoint(deal_id), headers(access_token))
       end
 
       private

--- a/lib/easy_hubspot/line_item.rb
+++ b/lib/easy_hubspot/line_item.rb
@@ -6,24 +6,24 @@ module EasyHubspot
     class << self
       LINE_ITEM_ENDPOINT = 'crm/v3/objects/line_items'
 
-      def get_line_item(line_item_id)
-        Client.do_get(line_item_id_endpoint(line_item_id), headers)
+      def get_line_item(line_item_id, access_token = nil)
+        Client.do_get(line_item_id_endpoint(line_item_id), headers(access_token))
       end
 
-      def get_line_items
-        Client.do_get(LINE_ITEM_ENDPOINT, headers)
+      def get_line_items(access_token = nil)
+        Client.do_get(LINE_ITEM_ENDPOINT, headers(access_token))
       end
 
-      def create_line_item(body)
-        Client.do_post(LINE_ITEM_ENDPOINT, body, headers)
+      def create_line_item(body, access_token = nil)
+        Client.do_post(LINE_ITEM_ENDPOINT, body, headers(access_token))
       end
 
-      def update_line_item(line_item_id, body)
-        Client.do_patch(line_item_id_endpoint(line_item_id), body, headers)
+      def update_line_item(line_item_id, body, access_token = nil)
+        Client.do_patch(line_item_id_endpoint(line_item_id), body, headers(access_token))
       end
 
-      def delete_line_item(line_item_id)
-        Client.do_delete(line_item_id_endpoint(line_item_id), headers)
+      def delete_line_item(line_item_id, access_token = nil)
+        Client.do_delete(line_item_id_endpoint(line_item_id), headers(access_token))
       end
 
       private

--- a/lib/easy_hubspot/product.rb
+++ b/lib/easy_hubspot/product.rb
@@ -6,24 +6,24 @@ module EasyHubspot
     class << self
       PRODUCT_ENDPOINT = 'crm/v3/objects/products'
 
-      def get_product(product_id)
-        Client.do_get(product_id_endpoint(product_id), headers)
+      def get_product(product_id, access_token = nil)
+        Client.do_get(product_id_endpoint(product_id), headers(access_token))
       end
 
-      def get_products
-        Client.do_get(PRODUCT_ENDPOINT, headers)
+      def get_products(access_token = nil)
+        Client.do_get(PRODUCT_ENDPOINT, headers(access_token))
       end
 
-      def create_product(body)
-        Client.do_post(PRODUCT_ENDPOINT, body, headers)
+      def create_product(body, access_token = nil)
+        Client.do_post(PRODUCT_ENDPOINT, body, headers(access_token))
       end
 
-      def update_product(product_id, body)
-        Client.do_patch(product_id_endpoint(product_id), body, headers)
+      def update_product(product_id, body, access_token = nil)
+        Client.do_patch(product_id_endpoint(product_id), body, headers(access_token))
       end
 
-      def delete_product(product_id)
-        Client.do_delete(product_id_endpoint(product_id), headers)
+      def delete_product(product_id, access_token = nil)
+        Client.do_delete(product_id_endpoint(product_id), headers(access_token))
       end
 
       private

--- a/lib/easy_hubspot/version.rb
+++ b/lib/easy_hubspot/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module EasyHubspot
-  VERSION = '1.0.1'
+  VERSION = '1.0.2'
 end

--- a/spec/easy_hubspot/base_spec.rb
+++ b/spec/easy_hubspot/base_spec.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe EasyHubspot::Base do
+  global_access_token = 'YOUR-GLOBAL-ACCESS-TOKEN'
+
+  before :all do
+    EasyHubspot.config do |config|
+      config.access_token = global_access_token
+    end
+  end
+
+  describe '#headers' do
+    context 'when using the global access_token' do
+      let(:expected_headers) {
+        { "Content-Type" => 'application/json', "Authorization" => "Bearer #{global_access_token}" }
+      }
+
+      it 'returns the expected Authorization Header' do
+        expect(described_class.headers).to eq(expected_headers)
+      end
+    end
+
+    context 'when overriding the global access_token' do
+      let(:custom_access_token) { 'CUSTOM-PER-CALL-ACCESS-TOKEN' }
+      let(:expected_headers) {
+        { "Content-Type" => 'application/json', "Authorization" => "Bearer #{custom_access_token}" }
+      }
+
+      it 'returns the expected Authorization Header' do
+        expect(described_class.headers(custom_access_token)).to eq(expected_headers)
+      end
+    end
+  end
+end

--- a/spec/easy_hubspot/base_spec.rb
+++ b/spec/easy_hubspot/base_spec.rb
@@ -13,9 +13,9 @@ RSpec.describe EasyHubspot::Base do
 
   describe '#headers' do
     context 'when using the global access_token' do
-      let(:expected_headers) {
-        { "Content-Type" => 'application/json', "Authorization" => "Bearer #{global_access_token}" }
-      }
+      let(:expected_headers) do
+        { 'Content-Type' => 'application/json', 'Authorization' => "Bearer #{global_access_token}" }
+      end
 
       it 'returns the expected Authorization Header' do
         expect(described_class.headers).to eq(expected_headers)
@@ -24,9 +24,9 @@ RSpec.describe EasyHubspot::Base do
 
     context 'when overriding the global access_token' do
       let(:custom_access_token) { 'CUSTOM-PER-CALL-ACCESS-TOKEN' }
-      let(:expected_headers) {
-        { "Content-Type" => 'application/json', "Authorization" => "Bearer #{custom_access_token}" }
-      }
+      let(:expected_headers) do
+        { 'Content-Type' => 'application/json', 'Authorization' => "Bearer #{custom_access_token}" }
+      end
 
       it 'returns the expected Authorization Header' do
         expect(described_class.headers(custom_access_token)).to eq(expected_headers)

--- a/spec/easy_hubspot/contact_spec.rb
+++ b/spec/easy_hubspot/contact_spec.rb
@@ -136,7 +136,7 @@ RSpec.describe EasyHubspot::Contact do
       it 'uses the correct access token' do
         described_class.get_contacts(overwrite_access_token)
         expect(EasyHubspot::Client).to have_received(:do_get)
-          .with(request_endpoint, expected_overwritten_headers_method_output)
+                                         .with(request_endpoint, expected_overwritten_headers_method_output)
       end
     end
   end
@@ -436,10 +436,8 @@ RSpec.describe EasyHubspot::Contact do
 
   describe 'update_or_create_contact' do
     context 'when contact is found using contact_id' do
-      let!(:email) { 'amber_becker@quigley.io' }
-      let(:response) { described_class.update_or_create_contact(email, body) }
       let!(:body) do
-        { properties: { email: email, firstname: 'Amber', lastname: 'Quigley', hs_content_membership_status: 'inactive' } }
+        { properties: { email: 'amber_becker@quigley.io', firstname: 'Amber', lastname: 'Quigley', hs_content_membership_status: 'inactive' } }
       end
 
       before do
@@ -469,16 +467,15 @@ RSpec.describe EasyHubspot::Contact do
       end
 
       it 'updates the contact' do
+        response = described_class.update_or_create_contact('amber_becker@quigley.io', body)
         expect(response).to eq JSON.parse load_contact_json('update_or_create_contact'), symbolize_names: true
       end
     end
 
     context "when contact isn't found" do
-      let!(:email) { 'not_found@gmail.com' }
       let!(:body) do
-        { properties: { email: email, firstname: 'Not', lastname: 'Found', hs_content_membership_status: 'active' } }
+        { properties: { email: 'not_found@gmail.com', firstname: 'Not', lastname: 'Found', hs_content_membership_status: 'active' } }
       end
-      let(:response) { described_class.update_or_create_contact(email, body) }
 
       before do
         stub_request(:get, 'https://api.hubapi.com/crm/v3/objects/contacts/not_found@gmail.com?idProperty=email')
@@ -507,6 +504,7 @@ RSpec.describe EasyHubspot::Contact do
       end
 
       it 'creates the contact' do
+        response = described_class.update_or_create_contact('not_found@gmail.com', body)
         expect(response).to eq JSON.parse load_contact_json('update_or_create_post'), symbolize_names: true
       end
     end

--- a/spec/easy_hubspot/contact_spec.rb
+++ b/spec/easy_hubspot/contact_spec.rb
@@ -136,7 +136,7 @@ RSpec.describe EasyHubspot::Contact do
       it 'uses the correct access token' do
         described_class.get_contacts(overwrite_access_token)
         expect(EasyHubspot::Client).to have_received(:do_get)
-                                         .with(request_endpoint, expected_overwritten_headers_method_output)
+          .with(request_endpoint, expected_overwritten_headers_method_output)
       end
     end
   end
@@ -189,7 +189,8 @@ RSpec.describe EasyHubspot::Contact do
         described_class.create_contact(body, overwrite_access_token)
         expect(EasyHubspot::Client).to(
           have_received(:do_post)
-            .with('crm/v3/objects/contacts', body, expected_overwritten_headers_method_output))
+            .with('crm/v3/objects/contacts', body, expected_overwritten_headers_method_output)
+        )
       end
     end
   end
@@ -349,7 +350,8 @@ RSpec.describe EasyHubspot::Contact do
         described_class.delete_contact('example@gmail.com', overwrite_access_token)
         expect(EasyHubspot::Client).to(
           have_received(:do_delete)
-            .with('crm/v3/objects/contacts/example@gmail.com?idProperty=email', expected_overwritten_headers_method_output))
+            .with('crm/v3/objects/contacts/example@gmail.com?idProperty=email', expected_overwritten_headers_method_output)
+        )
       end
     end
   end

--- a/spec/easy_hubspot/contact_spec.rb
+++ b/spec/easy_hubspot/contact_spec.rb
@@ -136,7 +136,7 @@ RSpec.describe EasyHubspot::Contact do
       it 'uses the correct access token' do
         described_class.get_contacts(overwrite_access_token)
         expect(EasyHubspot::Client).to have_received(:do_get)
-                                         .with(request_endpoint, expected_overwritten_headers_method_output)
+          .with(request_endpoint, expected_overwritten_headers_method_output)
       end
     end
   end

--- a/spec/easy_hubspot/deal_spec.rb
+++ b/spec/easy_hubspot/deal_spec.rb
@@ -31,7 +31,6 @@ RSpec.describe EasyHubspot::Deal do
         expect(response[:id]).to eq '11733930097'
         expect(response[:properties][:amount]).to eq '145.23'
       end
-
     end
 
     context 'when deal is found using deal_id and a different access token' do
@@ -63,7 +62,6 @@ RSpec.describe EasyHubspot::Deal do
                                                                    { 'Authorization' => 'Bearer ANOTHER-ACCESS-TOKEN',
                                                                      'Content-Type' => 'application/json' }))
       end
-
     end
   end
 

--- a/spec/easy_hubspot/deal_spec.rb
+++ b/spec/easy_hubspot/deal_spec.rb
@@ -31,6 +31,39 @@ RSpec.describe EasyHubspot::Deal do
         expect(response[:id]).to eq '11733930097'
         expect(response[:properties][:amount]).to eq '145.23'
       end
+
+    end
+
+    context 'when deal is found using deal_id and a different access token' do
+      before do
+        stub_request(:get, 'https://api.hubapi.com/crm/v3/objects/deals/11733930097')
+          .with(
+            headers: {
+              'Accept' => '*/*',
+              'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
+              'Authorization' => 'Bearer ANOTHER-ACCESS-TOKEN',
+              'Content-Type' => 'application/json',
+              'User-Agent' => 'Ruby'
+            }
+          )
+          .to_return(status: 200, body: load_deal_json('get_deal'), headers: {})
+        allow(EasyHubspot::Client).to receive(:do_get).and_call_original
+      end
+
+      it 'returns a deal' do
+        response = described_class.get_deal('11733930097', 'ANOTHER-ACCESS-TOKEN')
+        expect(response[:id]).to eq '11733930097'
+        expect(response[:properties][:amount]).to eq '145.23'
+      end
+
+      it 'called headers with the right arguments' do
+        described_class.get_deal('11733930097', 'ANOTHER-ACCESS-TOKEN')
+
+        expect(EasyHubspot::Client).to(have_received(:do_get).with('crm/v3/objects/deals/11733930097',
+                                                                   { 'Authorization' => 'Bearer ANOTHER-ACCESS-TOKEN',
+                                                                     'Content-Type' => 'application/json' }))
+      end
+
     end
   end
 
@@ -38,16 +71,21 @@ RSpec.describe EasyHubspot::Deal do
     context 'when deals are found' do
       before do
         stub_request(:get, 'https://api.hubapi.com/crm/v3/objects/deals')
-          .with(
-            headers: {
-              'Accept' => '*/*',
-              'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
-              'Authorization' => 'Bearer YOUR-PRIVATE-ACCESS-TOKEN',
-              'Content-Type' => 'application/json',
-              'User-Agent' => 'Ruby'
-            }
-          )
+          .with(headers: { 'Accept' => '*/*',
+                           'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
+                           'Authorization' => 'Bearer YOUR-PRIVATE-ACCESS-TOKEN',
+                           'Content-Type' => 'application/json',
+                           'User-Agent' => 'Ruby' })
           .to_return(status: 200, body: load_deal_json('get_deals'), headers: {})
+
+        stub_request(:get, 'https://api.hubapi.com/crm/v3/objects/deals')
+          .with(headers: { 'Accept' => '*/*',
+                           'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
+                           'Authorization' => 'Bearer ANOTHER-ACCESS-TOKEN',
+                           'Content-Type' => 'application/json',
+                           'User-Agent' => 'Ruby' })
+          .to_return(status: 200, body: load_deal_json('get_deals'), headers: {})
+        allow(EasyHubspot::Base).to receive(:headers).and_call_original
       end
 
       let(:response) { described_class.get_deals }
@@ -55,6 +93,11 @@ RSpec.describe EasyHubspot::Deal do
       it 'returns a list of deals' do
         results = response[:results]
         expect(results.count).to eq 2
+      end
+
+      it 'calls for headers with the right access token' do
+        described_class.get_deals('ANOTHER-ACCESS-TOKEN')
+        expect(EasyHubspot::Base).to(have_received(:headers).with('ANOTHER-ACCESS-TOKEN'))
       end
     end
   end
@@ -73,6 +116,21 @@ RSpec.describe EasyHubspot::Deal do
           }
         )
         .to_return(status: 200, body: load_deal_json('create_deal'), headers: {})
+
+      stub_request(:post, 'https://api.hubapi.com/crm/v3/objects/deals')
+        .with(
+          body: 'properties%5Bamount%5D=1500.00&properties%5Bclosedate%5D=2023-12-07T16%3A50%3A06.678Z&properties%5Bdealname%5D=New%20Big%20Deal&properties%5Bpipeline%5D=default',
+          headers: {
+            'Accept' => '*/*',
+            'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
+            'Authorization' => 'Bearer ANOTHER-ACCESS-TOKEN',
+            'Content-Type' => 'application/json',
+            'User-Agent' => 'Ruby'
+          }
+        )
+        .to_return(status: 200, body: load_deal_json('create_deal'), headers: {})
+
+      allow(EasyHubspot::Base).to receive(:headers).and_call_original
     end
 
     let(:body) do
@@ -85,6 +143,11 @@ RSpec.describe EasyHubspot::Deal do
       expect(response[:properties][:amount]).to eq '1500.00'
       expect(response[:properties][:closedate]).to eq '2023-12-07T16:50:06.678Z'
       expect(response[:properties][:dealname]).to eq 'New Big Deal'
+    end
+
+    it 'calls for headers with the right access token' do
+      described_class.create_deal(body, 'ANOTHER-ACCESS-TOKEN')
+      expect(EasyHubspot::Base).to(have_received(:headers).with('ANOTHER-ACCESS-TOKEN'))
     end
   end
 
@@ -103,6 +166,20 @@ RSpec.describe EasyHubspot::Deal do
             }
           )
           .to_return(status: 200, body: load_deal_json('update_deal'), headers: {})
+
+        stub_request(:patch, 'https://api.hubapi.com/crm/v3/objects/deals/12259629202')
+          .with(
+            body: 'properties%5Bamount%5D=1600.00&properties%5Bclosedate%5D=2023-11-07T16%3A50%3A06.678Z&properties%5Bdealname%5D=New%20Big%20Deal%20UPDATE&properties%5Bpipeline%5D=default',
+            headers: {
+              'Accept' => '*/*',
+              'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
+              'Authorization' => 'Bearer ANOTHER-ACCESS-TOKEN',
+              'Content-Type' => 'application/json',
+              'User-Agent' => 'Ruby'
+            }
+          )
+          .to_return(status: 200, body: load_deal_json('update_deal'), headers: {})
+        allow(EasyHubspot::Base).to receive(:headers).and_call_original
       end
 
       let(:body) do
@@ -115,6 +192,11 @@ RSpec.describe EasyHubspot::Deal do
         expect(response[:properties][:amount]).to eq '1600.00'
         expect(response[:properties][:closedate]).to eq '2023-11-07T16:50:06.678Z'
         expect(response[:properties][:dealname]).to eq 'New Big Deal UPDATE'
+      end
+
+      it 'calls for headers with the right arguments' do
+        described_class.update_deal(12_259_629_202, body, 'ANOTHER-ACCESS-TOKEN')
+        expect(EasyHubspot::Base).to(have_received(:headers).with('ANOTHER-ACCESS-TOKEN'))
       end
     end
   end
@@ -135,12 +217,30 @@ RSpec.describe EasyHubspot::Deal do
             }
           )
           .to_return(status: 204, body: '', headers: {})
+
+        stub_request(:delete, 'https://api.hubapi.com/crm/v3/objects/deals/12259629202')
+          .with(
+            headers: {
+              'Accept' => '*/*',
+              'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
+              'Authorization' => 'Bearer ANOTHER-ACCESS-TOKEN',
+              'Content-Type' => 'application/json',
+              'User-Agent' => 'Ruby'
+            }
+          )
+          .to_return(status: 204, body: '', headers: {})
+        allow(EasyHubspot::Base).to receive(:headers).and_call_original
       end
 
       let(:response) { described_class.delete_deal('12259629202') }
 
       it 'returns no content' do
         expect(response).to eq success
+      end
+
+      it 'headers to be fetched with the right access token' do
+        described_class.delete_deal('12259629202', 'ANOTHER-ACCESS-TOKEN')
+        expect(EasyHubspot::Base).to(have_received(:headers).with('ANOTHER-ACCESS-TOKEN'))
       end
     end
   end

--- a/spec/easy_hubspot/product_spec.rb
+++ b/spec/easy_hubspot/product_spec.rb
@@ -23,6 +23,19 @@ RSpec.describe EasyHubspot::Product do
             }
           )
           .to_return(status: 200, body: load_product_json('get_product'), headers: {})
+
+        stub_request(:get, 'https://api.hubapi.com/crm/v3/objects/products/1172707032')
+          .with(
+            headers: {
+              'Accept' => '*/*',
+              'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
+              'Authorization' => 'Bearer ANOTHER-ACCESS-TOKEN',
+              'Content-Type' => 'application/json',
+              'User-Agent' => 'Ruby'
+            }
+          )
+          .to_return(status: 200, body: load_product_json('get_product'), headers: {})
+        allow(EasyHubspot::Base).to receive(:headers).and_call_original
       end
 
       let(:response) { described_class.get_product('1172707032') }
@@ -30,6 +43,11 @@ RSpec.describe EasyHubspot::Product do
       it 'returns a product' do
         expect(response[:id]).to eq '1172707032'
         expect(response[:properties][:price]).to eq '25'
+      end
+
+      it 'calls for headers with the right token' do
+        described_class.get_product('1172707032', 'ANOTHER-ACCESS-TOKEN')
+        expect(EasyHubspot::Base).to have_received(:headers).with('ANOTHER-ACCESS-TOKEN')
       end
     end
   end
@@ -48,6 +66,19 @@ RSpec.describe EasyHubspot::Product do
             }
           )
           .to_return(status: 200, body: load_product_json('get_products'), headers: {})
+
+        stub_request(:get, 'https://api.hubapi.com/crm/v3/objects/products')
+          .with(
+            headers: {
+              'Accept' => '*/*',
+              'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
+              'Authorization' => 'Bearer ANOTHER-ACCESS-TOKEN',
+              'Content-Type' => 'application/json',
+              'User-Agent' => 'Ruby'
+            }
+          )
+          .to_return(status: 200, body: load_product_json('get_products'), headers: {})
+        allow(EasyHubspot::Base).to receive(:headers).and_call_original
       end
 
       let(:response) { described_class.get_products }
@@ -55,6 +86,11 @@ RSpec.describe EasyHubspot::Product do
       it 'returns a list of products' do
         results = response[:results]
         expect(results.count).to eq 2
+      end
+
+      it 'calls for headers with the right access token' do
+        described_class.get_products('ANOTHER-ACCESS-TOKEN')
+        expect(EasyHubspot::Base).to have_received(:headers).with('ANOTHER-ACCESS-TOKEN')
       end
     end
   end
@@ -73,6 +109,20 @@ RSpec.describe EasyHubspot::Product do
           }
         )
         .to_return(status: 200, body: load_product_json('create_product'), headers: {})
+
+      stub_request(:post, 'https://api.hubapi.com/crm/v3/objects/products')
+        .with(
+          body: 'properties%5Bprice%5D=75.00&properties%5Bname%5D=Blue%20Jeans&properties%5Bdescription%5D=Worn',
+          headers: {
+            'Accept' => '*/*',
+            'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
+            'Authorization' => 'Bearer ANOTHER-ACCESS-TOKEN',
+            'Content-Type' => 'application/json',
+            'User-Agent' => 'Ruby'
+          }
+        )
+        .to_return(status: 200, body: load_product_json('create_product'), headers: {})
+      allow(EasyHubspot::Base).to receive(:headers).and_call_original
     end
 
     let(:body) do
@@ -85,6 +135,11 @@ RSpec.describe EasyHubspot::Product do
       expect(response[:properties][:price]).to eq '75.00'
       expect(response[:properties][:name]).to eq 'Blue Jeans'
       expect(response[:properties][:description]).to eq 'Worn'
+    end
+
+    it 'called for headers with the right access code' do
+      described_class.create_product(body, 'ANOTHER-ACCESS-TOKEN')
+      expect(EasyHubspot::Base).to have_received(:headers).with('ANOTHER-ACCESS-TOKEN')
     end
   end
 
@@ -103,6 +158,19 @@ RSpec.describe EasyHubspot::Product do
             }
           )
           .to_return(status: 200, body: load_product_json('update_product'), headers: {})
+        stub_request(:patch, 'https://api.hubapi.com/crm/v3/objects/products/1174789087')
+          .with(
+            body: 'properties%5Bprice%5D=100.00&properties%5Bname%5D=New',
+            headers: {
+              'Accept' => '*/*',
+              'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
+              'Authorization' => 'Bearer ANOTHER-ACCESS-TOKEN',
+              'Content-Type' => 'application/json',
+              'User-Agent' => 'Ruby'
+            }
+          )
+          .to_return(status: 200, body: load_product_json('update_product'), headers: {})
+        allow(EasyHubspot::Base).to receive(:headers).and_call_original
       end
 
       let(:body) do
@@ -114,6 +182,11 @@ RSpec.describe EasyHubspot::Product do
         expect(response[:id]).to eq '1174789087'
         expect(response[:properties][:price]).to eq '100.00'
         expect(response[:properties][:description]).to eq 'New'
+      end
+
+      it 'calls for headers with the right access token' do
+        described_class.update_product(1_174_789_087, body, 'ANOTHER-ACCESS-TOKEN')
+        expect(EasyHubspot::Base).to have_received(:headers).with('ANOTHER-ACCESS-TOKEN')
       end
     end
   end
@@ -134,12 +207,30 @@ RSpec.describe EasyHubspot::Product do
             }
           )
           .to_return(status: 204, body: '', headers: {})
+
+        stub_request(:delete, 'https://api.hubapi.com/crm/v3/objects/products/1174789087')
+          .with(
+            headers: {
+              'Accept' => '*/*',
+              'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
+              'Authorization' => 'Bearer ANOTHER-ACCESS-TOKEN',
+              'Content-Type' => 'application/json',
+              'User-Agent' => 'Ruby'
+            }
+          )
+          .to_return(status: 204, body: '', headers: {})
+        allow(EasyHubspot::Base).to receive(:headers).and_call_original
       end
 
       let(:response) { described_class.delete_product('1174789087') }
 
       it 'returns no content' do
         expect(response).to eq success
+      end
+
+      it 'calls for headers with the right access token' do
+        described_class.delete_product('1174789087', 'ANOTHER-ACCESS-TOKEN')
+        expect(EasyHubspot::Base).to have_received(:headers).with('ANOTHER-ACCESS-TOKEN')
       end
     end
   end


### PR DESCRIPTION
This PR adds functionality to overwrite HubSpot access-token at call time.
The idea is use the gem in a multi-tenant environment where not everyone uses the same hubspot account.